### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/Samedis-care/samedis-care-staff-sync/security/code-scanning/1](https://github.com/Samedis-care/samedis-care-staff-sync/security/code-scanning/1)

To fix the problem, you should add a `permissions` block at the appropriate level in the workflow file. Since the workflow currently contains only one job and its steps do not require write access to the repository, the least privileged setting would be `contents: read`. This should be placed at the root level (above `jobs:`), to ensure all jobs in the workflow default to these minimal permissions. No imports or additional code are required—just a declarative change to the workflow YAML file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
